### PR TITLE
smarty3.x に対応

### DIFF
--- a/data/Smarty/templates/admin/contents/recommend_search.tpl
+++ b/data/Smarty/templates/admin/contents/recommend_search.tpl
@@ -104,8 +104,8 @@ function func_submit( id ){
                 <img src="<!--{$smarty.const.IMAGE_SAVE_URLPATH}--><!--{$arr.main_list_image|sfNoImageMainList|h}-->" style="max-width: 65px;max-height: 65;" alt="" />
             </td>
             <td>
-                <!--{assign var=codemin value=`$arr.product_code_min`}-->
-                <!--{assign var=codemax value=`$arr.product_code_max`}-->
+                <!--{assign var=codemin value="`$arr.product_code_min`"}-->
+                <!--{assign var=codemax value="`$arr.product_code_max`"}-->
                 <!--{* 商品コード *}-->
                 <!--{if $codemin != $codemax}-->
                     <!--{$codemin|h}-->～<!--{$codemax|h}-->

--- a/data/Smarty/templates/admin/customer/edit.tpl
+++ b/data/Smarty/templates/admin/customer/edit.tpl
@@ -208,7 +208,7 @@
                     </select>月
                     <select name="day" <!--{if $arrErr.year != ""}--><!--{sfSetErrorStyle}--><!--{/if}--> >
                         <option value="" selected="selected">----</option>
-                        <!--{html_options options=$arrDay selected=$arrForm.day"}-->
+                        <!--{html_options options=$arrDay selected=$arrForm.day}-->
                     </select>日
                 </td>
             </tr>

--- a/data/Smarty/templates/admin/design/bloc.tpl
+++ b/data/Smarty/templates/admin/design/bloc.tpl
@@ -58,7 +58,7 @@
             <tr>
                 <td colspan="2">
                     <!--{assign var=key value="bloc_html"}-->
-                    <textarea class="top" id="<!--{$key}-->" name="<!--{$key}-->" rows="<!--{$text_row}-->" style="width: 99%;"><!--{"\n"}--><!--{$arrForm[$key].value|smarty:nodefaults|h}--></textarea>
+                    <textarea class="top" id="<!--{$key}-->" name="<!--{$key}-->" rows="<!--{$text_row}-->" style="width: 99%;"><!--{"\n"}--><!--{$arrForm[$key].value|h nofilter}--></textarea>
                     <input type="hidden" name="html_area_row" value="<!--{$text_row}-->" />
                     <div>
                         <a id="resize-btn" class="btn-normal" href="javascript:;" onclick="eccube.toggleRows('#resize-btn', '#bloc_html', 50, 13); return false;">拡大</a>

--- a/data/Smarty/templates/admin/design/header.tpl
+++ b/data/Smarty/templates/admin/design/header.tpl
@@ -39,7 +39,7 @@
         <input type="hidden" name="header_row" value="<!--{$header_row}-->" />
         <input type="hidden" name="device_type_id" value="<!--{$device_type_id|h}-->" />
 
-        <textarea id="header-area" class="top" name="header" rows="<!--{$header_row}-->" style="width: 100%;"><!--{"\n"}--><!--{$header_data|h|smarty:nodefaults}--></textarea>
+        <textarea id="header-area" class="top" name="header" rows="<!--{$header_row}-->" style="width: 100%;"><!--{"\n"}--><!--{$header_data nofilter}--></textarea>
         <div class="btn">
             <a id="header-area-resize-btn" class="btn-normal" href="javascript:;" onclick="eccube.toggleRows('#header-area-resize-btn', '#header-area', 50, 13); $('input[name=header_row]').val($('#header-area').attr('rows'));return false;"><span>拡大</span></a>
         </div>
@@ -62,7 +62,7 @@
         <input type="hidden" name="footer_row" value="<!--{$footer_row}-->" />
         <input type="hidden" name="device_type_id" value="<!--{$device_type_id|h}-->" />
 
-        <textarea id="footer-area" class="top" name="footer" rows="<!--{$footer_row}-->" style="width: 100%;"><!--{"\n"}--><!--{$footer_data|h|smarty:nodefaults}--></textarea>
+        <textarea id="footer-area" class="top" name="footer" rows="<!--{$footer_row}-->" style="width: 100%;"><!--{"\n"}--><!--{$footer_data nofilter}--></textarea>
         <div class="btn">
             <a id="footer-area-resize-btn" class="btn-normal" href="javascript:;" onclick="eccube.toggleRows('#footer-area-resize-btn', '#footer-area', 50, 13); $('input[name=footer_row]').val($('#footer-area').attr('rows'));return false;"><span>拡大</span></a>
         </div>

--- a/data/Smarty/templates/admin/design/main_edit.tpl
+++ b/data/Smarty/templates/admin/design/main_edit.tpl
@@ -81,7 +81,7 @@ function fnTargetSelf(){
                 <label for="header-chk"><input type="checkbox" name="header_chk" id="header-chk" value="1" <!--{if $arrForm.header_chk.value == "1"}-->checked="checked"<!--{/if}--> />共通のヘッダーを使用する</label>&nbsp;
                 <label for="footer-chk"><input type="checkbox" name="footer_chk" id="footer-chk" value="1" <!--{if $arrForm.footer_chk.value == "1"}-->checked="checked"<!--{/if}--> />共通のフッターを使用する</label>
                 <div>
-                    <textarea id="tpl_data" class="top" name="tpl_data" rows="<!--{$text_row}-->" style="width: 98%;"><!--{"\n"}--><!--{$arrForm.tpl_data.value|h|smarty:nodefaults}--></textarea>
+                    <textarea id="tpl_data" class="top" name="tpl_data" rows="<!--{$text_row}-->" style="width: 98%;"><!--{"\n"}--><!--{$arrForm.tpl_data.value nofilter}--></textarea>
                     <input type="hidden" name="html_area_row" value="<!--{$text_row}-->" /><br />
                     <a id="resize-btn" class="btn-normal" href="javascript:;" onclick="eccube.toggleRows('#resize-btn', '#tpl_data', 50, 13); return false;"><span>拡大</span></a>
                 </div>

--- a/data/Smarty/templates/admin/main_frame.tpl
+++ b/data/Smarty/templates/admin/main_frame.tpl
@@ -65,7 +65,7 @@
 <!--{if $arrPageLayout.HeadNavi|@count > 0}-->
     <!--{foreach key=HeadNaviKey item=HeadNaviItem from=$arrPageLayout.HeadNavi}-->
         <!--{if $HeadNaviItem.php_path != ""}-->
-            <!--{include_php file=$HeadNaviItem.php_path}-->
+            <!--{include_php_ex file=$HeadNaviItem.php_path}-->
         <!--{/if}-->
     <!--{/foreach}-->
 <!--{/if}-->

--- a/data/Smarty/templates/admin/order/disp.tpl
+++ b/data/Smarty/templates/admin/order/disp.tpl
@@ -179,10 +179,10 @@
             <td class="right">
                 <!--{$arrForm.quantity.value[$product_index]|h}-->
             </td>
-                <!--{assign var=price value=`$arrForm.price.value[$product_index]`}-->
-                <!--{assign var=quantity value=`$arrForm.quantity.value[$product_index]`}-->
-                <!--{assign var=tax_rate value=`$arrForm.tax_rate.value[$product_index]`}-->
-                <!--{assign var=tax_rule value=`$arrForm.tax_rule.value[$product_index]`}-->
+                <!--{assign var=price value="`$arrForm.price.value[$product_index]`"}-->
+                <!--{assign var=quantity value="`$arrForm.quantity.value[$product_index]`"}-->
+                <!--{assign var=tax_rate value="`$arrForm.tax_rate.value[$product_index]`"}-->
+                <!--{assign var=tax_rule value="`$arrForm.tax_rule.value[$product_index]`"}-->
             <td class="right"><!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|n2s}--> 円<br />(税率<!--{$tax_rate|n2s}-->%)</td>
             <td class="right"><!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|sfMultiply:$quantity|n2s}-->円</td>
         </tr>

--- a/data/Smarty/templates/admin/order/edit.tpl
+++ b/data/Smarty/templates/admin/order/edit.tpl
@@ -422,10 +422,10 @@
                         <span class="attention"><!--{$arrErr[$key][$product_index]}--></span>
                         <input type="text" name="<!--{$key}-->[<!--{$product_index}-->]" value="<!--{$arrForm[$key].value[$product_index]|h}-->" size="3" class="box3" maxlength="<!--{$arrForm[$key].length}-->" style="<!--{$arrErr[$key][$product_index]|sfGetErrorColor}-->" id="<!--{$key}-->_<!--{$product_index}-->"  onChange="quantityCopyForSingleShipping('<!--{$product_index}-->')" />
                     </td>
-                    <!--{assign var=price value=`$arrForm.price.value[$product_index]`}-->
-                    <!--{assign var=quantity value=`$arrForm.quantity.value[$product_index]`}-->
-                    <!--{assign var=tax_rate value=`$arrForm.tax_rate.value[$product_index]`}-->
-                    <!--{assign var=tax_rule value=`$arrForm.tax_rule.value[$product_index]`}-->
+                    <!--{assign var=price value="`$arrForm.price.value[$product_index]`"}-->
+                    <!--{assign var=quantity value="`$arrForm.quantity.value[$product_index]`"}-->
+                    <!--{assign var=tax_rate value="`$arrForm.tax_rate.value[$product_index]`"}-->
+                    <!--{assign var=tax_rule value="`$arrForm.tax_rule.value[$product_index]`"}-->
                     <input type="hidden" name="tax_rule[<!--{$product_index}-->]" value="<!--{$arrForm.tax_rule.value[$product_index]|h}-->" id="tax_rule_<!--{$product_index}-->" />
     
                     <td class="right">

--- a/data/Smarty/templates/admin/order/index.tpl
+++ b/data/Smarty/templates/admin/order/index.tpl
@@ -359,7 +359,7 @@
                     <col width="9%" />
                     <col width="5%" />
                     <!--{* ペイジェントモジュール連携用 *}-->
-                    <!--{assign var=path value=`$smarty.const.MODULE_REALDIR`mdl_paygent/paygent_order_index.tpl}-->
+                    <!--{assign var=path value="`$smarty.const.MODULE_REALDIR`mdl_paygent/paygent_order_index.tpl"}-->
                     <!--{if file_exists($path)}-->
                         <!--{include file=$path}-->
                     <!--{else}-->

--- a/data/Smarty/templates/admin/order/product_select.tpl
+++ b/data/Smarty/templates/admin/order/product_select.tpl
@@ -177,8 +177,8 @@
                         <img src="<!--{$smarty.const.IMAGE_SAVE_URLPATH}--><!--{$arrProducts[cnt].main_list_image|sfNoImageMainList|h}-->" style="max-width: 65px;max-height: 65;" alt="<!--{$arrRecommend[$recommend_no].name|h}-->" />
                     </td>
                     <td>
-                        <!--{assign var=codemin value=`$arrProducts[cnt].product_code_min`}-->
-                        <!--{assign var=codemax value=`$arrProducts[cnt].product_code_max`}-->
+                        <!--{assign var=codemin value="`$arrProducts[cnt].product_code_min`"}-->
+                        <!--{assign var=codemax value="`$arrProducts[cnt].product_code_max`"}-->
                         <!--{* 商品コード *}-->
                         <!--{if $codemin != $codemax}-->
                             <!--{$codemin|h}-->～<!--{$codemax|h}-->

--- a/data/Smarty/templates/admin/order/status.tpl
+++ b/data/Smarty/templates/admin/order/status.tpl
@@ -93,7 +93,7 @@
                     <td class="center"><a href="#" onclick="eccube.openWindow('./disp.php?order_id=<!--{$arrStatus[cnt].order_id}-->','order_disp','800','900',{resizable:'no',focus:false}); return false;" ><!--{$arrStatus[cnt].order_id}--></a></td>
                     <td class="center"><!--{$arrStatus[cnt].create_date|sfDispDBDate}--></td>
                     <td><!--{$arrStatus[cnt].order_name01|h}--> <!--{$arrStatus[cnt].order_name02|h}--></td>
-                    <!--{assign var=payment_id value=`$arrStatus[cnt].payment_id`}-->
+                    <!--{assign var=payment_id value="`$arrStatus[cnt].payment_id`"}-->
                     <td class="center"><!--{$arrPayment[$payment_id]|h}--></td>
                     <td class="right"><!--{$arrStatus[cnt].total|n2s}--></td>
                     <td class="center"><!--{if $arrStatus[cnt].payment_date != ""}--><!--{$arrStatus[cnt].payment_date|sfDispDBDate:false}--><!--{else}-->未入金<!--{/if}--></td>

--- a/data/Smarty/templates/admin/products/category_tree_fork.tpl
+++ b/data/Smarty/templates/admin/products/category_tree_fork.tpl
@@ -42,7 +42,7 @@
             <!--{else}-->
                 <!--{assign var=disp_child value=0}-->
             <!--{/if}-->
-            <!--{if isset($child.children|smarty:nodefaults)}-->
+            <!--{if isset($child.children)}-->
                 <!--{include file="`$smarty.const.TEMPLATE_ADMIN_REALDIR`products/category_tree_fork.tpl" children=$child.children treeID="f`$child.category_id`" display=$disp_child}-->
             <!--{/if}-->
         </li>

--- a/data/Smarty/templates/admin/products/confirm.tpl
+++ b/data/Smarty/templates/admin/products/confirm.tpl
@@ -233,7 +233,7 @@
 
         <!--{* オペビルダー用 *}-->
         <!--{if "sfViewAdminOpe"|function_exists === TRUE}-->
-            <!--{include file=`$smarty.const.MODULE_REALDIR`mdl_opebuilder/admin_ope_view.tpl}-->
+            <!--{include file="`$smarty.const.MODULE_REALDIR`mdl_opebuilder/admin_ope_view.tpl"}-->
         <!--{/if}-->
 
         <!--{section name=cnt loop=$smarty.const.PRODUCTSUB_MAX}-->

--- a/data/Smarty/templates/admin/products/product.tpl
+++ b/data/Smarty/templates/admin/products/product.tpl
@@ -1,4 +1,4 @@
-<!--{*
+    <!--{*
 /*
  * This file is part of EC-CUBE
  *
@@ -361,7 +361,7 @@
 
     <!--{* オペビルダー用 *}-->
     <!--{if "sfViewAdminOpe"|function_exists === TRUE}-->
-    <!--{include file=`$smarty.const.MODULE_REALDIR`mdl_opebuilder/admin_ope_view.tpl}-->
+    <!--{include file="`$smarty.const.MODULE_REALDIR`mdl_opebuilder/admin_ope_view.tpl"}-->
     <!--{/if}-->
 
     <div class="btn">

--- a/data/Smarty/templates/admin/products/product_rank.tpl
+++ b/data/Smarty/templates/admin/products/product_rank.tpl
@@ -89,7 +89,7 @@
                                 <!--{* 商品画像 *}-->
                                 <img src="<!--{$smarty.const.IMAGE_SAVE_URLPATH}--><!--{$arrProductsList[cnt].main_list_image|sfNoImageMainList|h}-->" style="max-width: 65px;max-height: 65;" alt="<!--{$arrProducts[cnt].name|h}-->" />
                             </td>
-                            <!--{assign var=rank value=`$rank+1`}-->
+                            <!--{assign var=rank value="`$rank+1`"}-->
                             <td align="center">
                                 <!--{$rank}-->
                                 <!--{if $arrProductsList[cnt].status == "2"}--><br />(非公開)<!--{/if}-->

--- a/data/Smarty/templates/admin/products/product_rank_tree_fork.tpl
+++ b/data/Smarty/templates/admin/products/product_rank_tree_fork.tpl
@@ -42,7 +42,7 @@
             <!--{else}-->
                 <!--{assign var=disp_child value=0}-->
             <!--{/if}-->
-            <!--{if isset($child.children|smarty:nodefaults)}-->
+            <!--{if isset($child.children)}-->
                 <!--{include file="`$smarty.const.TEMPLATE_ADMIN_REALDIR`products/product_rank_tree_fork.tpl" children=$child.children treeID="f`$child.category_id`" display=$disp_child}-->
             <!--{/if}-->
         </li>

--- a/data/Smarty/templates/default/frontparts/bloc/calendar.tpl
+++ b/data/Smarty/templates/default/frontparts/bloc/calendar.tpl
@@ -26,7 +26,7 @@
         <h2><img src="<!--{$TPL_URLPATH}-->img/title/tit_bloc_calender.gif" alt="カレンダー" /></h2>
             <div class="block_body">
                 <!--{section name=num loop=$arrCalendar}-->
-                    <!--{assign var=arrCal value=`$arrCalendar[num]`}-->
+                    <!--{assign var=arrCal value="`$arrCalendar[num]`"}-->
                     <!--{section name=cnt loop=$arrCal}-->
                         <!--{if $smarty.section.cnt.first}-->
                             <table>

--- a/data/Smarty/templates/default/frontparts/bloc/category_tree_fork.tpl
+++ b/data/Smarty/templates/default/frontparts/bloc/category_tree_fork.tpl
@@ -30,7 +30,7 @@
                 <!--{else}-->
                     <!--{assign var=disp_child value=0}-->
                 <!--{/if}-->
-                <!--{if isset($child.children|smarty:nodefaults)}-->
+                <!--{if isset($child.children)}-->
                     <!--{include file="`$smarty.const.TEMPLATE_REALDIR`frontparts/bloc/category_tree_fork.tpl" children=$child.children display=$disp_child}-->
                 <!--{/if}-->
             </li>

--- a/data/Smarty/templates/default/header.tpl
+++ b/data/Smarty/templates/default/header.tpl
@@ -36,7 +36,7 @@
                     <!--{foreach key=HeaderInternalNaviKey item=HeaderInternalNaviItem from=$arrPageLayout.HeaderInternalNavi}-->
                         <!-- ▼<!--{$HeaderInternalNaviItem.bloc_name}--> -->
                         <!--{if $HeaderInternalNaviItem.php_path != ""}-->
-                            <!--{include_php file=$HeaderInternalNaviItem.php_path items=$HeaderInternalNaviItem}-->
+                            <!--{include_php_ex file=$HeaderInternalNaviItem.php_path items=$HeaderInternalNaviItem}-->
                         <!--{else}-->
                             <!--{include file=$HeaderInternalNaviItem.tpl_path items=$HeaderInternalNaviItem}-->
                         <!--{/if}-->

--- a/data/Smarty/templates/default/mypage/favorite.tpl
+++ b/data/Smarty/templates/default/mypage/favorite.tpl
@@ -27,7 +27,7 @@
     <!--{if $tpl_navi != ""}-->
         <!--{include file=$tpl_navi}-->
     <!--{else}-->
-        <!--{include file=`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl}-->
+        <!--{include file="`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl"}-->
     <!--{/if}-->
     <div id="mycontents_area">
         <form name="form1" id="form1" method="post" action="?">

--- a/data/Smarty/templates/default/mypage/index.tpl
+++ b/data/Smarty/templates/default/mypage/index.tpl
@@ -27,7 +27,7 @@
     <!--{if $tpl_navi != ""}-->
         <!--{include file=$tpl_navi}-->
     <!--{else}-->
-        <!--{include file=`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl}-->
+        <!--{include file="`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl"}-->
     <!--{/if}-->
     <div id="mycontents_area">
         <form name="form1" id="form1" method="post" action="?">

--- a/data/Smarty/templates/default/products/detail.tpl
+++ b/data/Smarty/templates/default/products/detail.tpl
@@ -357,8 +357,8 @@
                         <a href="<!--{$smarty.const.P_DETAIL_URLPATH}--><!--{$arrItem.product_id|u}-->">
                             <img src="<!--{$smarty.const.IMAGE_SAVE_URLPATH}--><!--{$arrItem.main_list_image|sfNoImageMainList|h}-->" style="max-width: 65px;max-height: 65px;" alt="<!--{$arrItem.name|h}-->" /></a>
                     </div>
-                    <!--{assign var=price02_min value=`$arrItem.price02_min_inctax`}-->
-                    <!--{assign var=price02_max value=`$arrItem.price02_max_inctax`}-->
+                    <!--{assign var=price02_min value="`$arrItem.price02_min_inctax`"}-->
+                    <!--{assign var=price02_max value="`$arrItem.price02_max_inctax`"}-->
                     <div class="productContents">
                         <h3><a href="<!--{$smarty.const.P_DETAIL_URLPATH}--><!--{$arrItem.product_id|u}-->"><!--{$arrItem.name|h}--></a></h3>
                         <p class="sale_price"><!--{$smarty.const.SALE_PRICE_TITLE}-->(税込)：<span class="price">

--- a/data/Smarty/templates/default/products/list.tpl
+++ b/data/Smarty/templates/default/products/list.tpl
@@ -133,7 +133,7 @@
             <!--▼ページナビ(上部)-->
             <form name="page_navi_top" id="page_navi_top" action="?">
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-                <!--{if $tpl_linemax > 0}--><!--{$smarty.capture.page_navi_body|smarty:nodefaults}--><!--{/if}-->
+                <!--{if $tpl_linemax > 0}--><!--{$smarty.capture.page_navi_body nofilter}--><!--{/if}-->
             </form>
             <!--▲ページナビ(上部)-->
         <!--{/if}-->
@@ -258,7 +258,7 @@
             <!--▼ページナビ(下部)-->
             <form name="page_navi_bottom" id="page_navi_bottom" action="?">
                 <input type="hidden" name="<!--{$smarty.const.TRANSACTION_ID_NAME}-->" value="<!--{$transactionid}-->" />
-                <!--{if $tpl_linemax > 0}--><!--{$smarty.capture.page_navi_body|smarty:nodefaults}--><!--{/if}-->
+                <!--{if $tpl_linemax > 0}--><!--{$smarty.capture.page_navi_body nofilter}--><!--{/if}-->
             </form>
             <!--▲ページナビ(下部)-->
         <!--{/if}-->

--- a/data/Smarty/templates/default/shopping/confirm.tpl
+++ b/data/Smarty/templates/default/shopping/confirm.tpl
@@ -115,7 +115,7 @@
                     <tr>
                         <th colspan="4" class="alignR" scope="row">値引き（ポイントご使用時）</th>
                         <td class="alignR">
-                            <!--{assign var=discount value=`$arrForm.use_point*$smarty.const.POINT_VALUE`}-->
+                            <!--{assign var=discount value="`$arrForm.use_point*$smarty.const.POINT_VALUE`"}-->
                             -<!--{$discount|n2s|default:0}-->円</td>
                     </tr>
                     <!--{/if}-->
@@ -158,7 +158,7 @@
                         <td>+<!--{$arrForm.add_point|n2s|default:0}-->Pt</td>
                     </tr>
                     <tr>
-                    <!--{assign var=total_point value=`$tpl_user_point-$arrForm.use_point+$arrForm.add_point`}-->
+                    <!--{assign var=total_point value="`$tpl_user_point-$arrForm.use_point+$arrForm.add_point`"}-->
                         <th scope="row">加算後のポイント</th>
                         <td><!--{$total_point|n2s}-->Pt</td>
                     </tr>

--- a/data/Smarty/templates/default/site_frame.tpl
+++ b/data/Smarty/templates/default/site_frame.tpl
@@ -81,7 +81,7 @@
         <!--{foreach key=HeadNaviKey item=HeadNaviItem from=$arrPageLayout.HeadNavi}-->
             <!--{* ▼<!--{$HeadNaviItem.bloc_name}--> *}-->
             <!--{if $HeadNaviItem.php_path != ""}-->
-                <!--{include_php file=$HeadNaviItem.php_path items=$HeadNaviItem}-->
+                <!--{include_php_ex file=$HeadNaviItem.php_path items=$HeadNaviItem}-->
             <!--{else}-->
                 <!--{include file=$HeadNaviItem.tpl_path}-->
             <!--{/if}-->

--- a/data/Smarty/templates/default/site_main.tpl
+++ b/data/Smarty/templates/default/site_main.tpl
@@ -37,7 +37,7 @@
                     <!--{foreach key=HeaderTopNaviKey item=HeaderTopNaviItem from=$arrPageLayout.HeaderTopNavi}-->
                         <!-- ▼<!--{$HeaderTopNaviItem.bloc_name}--> -->
                         <!--{if $HeaderTopNaviItem.php_path != ""}-->
-                            <!--{include_php file=$HeaderTopNaviItem.php_path items=$HeaderTopNaviItem}-->
+                            <!--{include_php_ex file=$HeaderTopNaviItem.php_path items=$HeaderTopNaviItem}-->
                         <!--{else}-->
                             <!--{include file=$HeaderTopNaviItem.tpl_path items=$HeaderTopNaviItem}-->
                         <!--{/if}-->
@@ -62,7 +62,7 @@
                         <!--{foreach key=TopNaviKey item=TopNaviItem from=$arrPageLayout.TopNavi}-->
                             <!-- ▼<!--{$TopNaviItem.bloc_name}--> -->
                             <!--{if $TopNaviItem.php_path != ""}-->
-                                <!--{include_php file=$TopNaviItem.php_path items=$TopNaviItem}-->
+                                <!--{include_php_ex file=$TopNaviItem.php_path items=$TopNaviItem}-->
                             <!--{else}-->
                                 <!--{include file=$TopNaviItem.tpl_path items=$TopNaviItem}-->
                             <!--{/if}-->
@@ -80,7 +80,7 @@
                         <!--{foreach key=LeftNaviKey item=LeftNaviItem from=$arrPageLayout.LeftNavi}-->
                             <!-- ▼<!--{$LeftNaviItem.bloc_name}--> -->
                             <!--{if $LeftNaviItem.php_path != ""}-->
-                                <!--{include_php file=$LeftNaviItem.php_path items=$LeftNaviItem}-->
+                                <!--{include_php_ex file=$LeftNaviItem.php_path items=$LeftNaviItem}-->
                             <!--{else}-->
                                 <!--{include file=$LeftNaviItem.tpl_path items=$LeftNaviItem}-->
                             <!--{/if}-->
@@ -104,7 +104,7 @@
                         <!--{foreach key=MainHeadKey item=MainHeadItem from=$arrPageLayout.MainHead}-->
                             <!-- ▼<!--{$MainHeadItem.bloc_name}--> -->
                             <!--{if $MainHeadItem.php_path != ""}-->
-                                <!--{include_php file=$MainHeadItem.php_path items=$MainHeadItem}-->
+                                <!--{include_php_ex file=$MainHeadItem.php_path items=$MainHeadItem}-->
                             <!--{else}-->
                                 <!--{include file=$MainHeadItem.tpl_path items=$MainHeadItem}-->
                             <!--{/if}-->
@@ -122,7 +122,7 @@
                         <!--{foreach key=MainFootKey item=MainFootItem from=$arrPageLayout.MainFoot}-->
                             <!-- ▼<!--{$MainFootItem.bloc_name}--> -->
                             <!--{if $MainFootItem.php_path != ""}-->
-                                <!--{include_php file=$MainFootItem.php_path items=$MainFootItem}-->
+                                <!--{include_php_ex file=$MainFootItem.php_path items=$MainFootItem}-->
                             <!--{else}-->
                                 <!--{include file=$MainFootItem.tpl_path items=$MainFootItem}-->
                             <!--{/if}-->
@@ -140,7 +140,7 @@
                         <!--{foreach key=RightNaviKey item=RightNaviItem from=$arrPageLayout.RightNavi}-->
                             <!-- ▼<!--{$RightNaviItem.bloc_name}--> -->
                             <!--{if $RightNaviItem.php_path != ""}-->
-                                <!--{include_php file=$RightNaviItem.php_path items=$RightNaviItem}-->
+                                <!--{include_php_ex file=$RightNaviItem.php_path items=$RightNaviItem}-->
                             <!--{else}-->
                                 <!--{include file=$RightNaviItem.tpl_path items=$RightNaviItem}-->
                             <!--{/if}-->
@@ -158,7 +158,7 @@
                         <!--{foreach key=BottomNaviKey item=BottomNaviItem from=$arrPageLayout.BottomNavi}-->
                             <!-- ▼<!--{$BottomNaviItem.bloc_name}--> -->
                             <!--{if $BottomNaviItem.php_path != ""}-->
-                                <!--{include_php file=$BottomNaviItem.php_path items=$BottomNaviItem}-->
+                                <!--{include_php_ex file=$BottomNaviItem.php_path items=$BottomNaviItem}-->
                             <!--{else}-->
                                 <!--{include file=$BottomNaviItem.tpl_path items=$BottomNaviItem}-->
                             <!--{/if}-->
@@ -183,7 +183,7 @@
                     <!--{foreach key=FooterBottomNaviKey item=FooterBottomNaviItem from=$arrPageLayout.FooterBottomNavi}-->
                         <!-- ▼<!--{$FooterBottomNaviItem.bloc_name}--> -->
                         <!--{if $FooterBottomNaviItem.php_path != ""}-->
-                            <!--{include_php file=$FooterBottomNaviItem.php_path items=$FooterBottomNaviItem}-->
+                            <!--{include_php_ex file=$FooterBottomNaviItem.php_path items=$FooterBottomNaviItem}-->
                         <!--{else}-->
                             <!--{include file=$FooterBottomNaviItem.tpl_path items=$FooterBottomNaviItem}-->
                         <!--{/if}-->

--- a/data/Smarty/templates/mobile/header.tpl
+++ b/data/Smarty/templates/mobile/header.tpl
@@ -28,7 +28,7 @@
         <!--{foreach key=HeaderInternalNaviKey item=HeaderInternalNaviItem from=$arrPageLayout.HeaderInternalNavi}-->
             <!-- ▼<!--{$HeaderInternalNaviItem.bloc_name}--> -->
             <!--{if $HeaderInternalNaviItem.php_path != ""}-->
-                <!--{include_php file=$HeaderInternalNaviItem.php_path items=$HeaderInternalNaviItem}-->
+                <!--{include_php_ex file=$HeaderInternalNaviItem.php_path items=$HeaderInternalNaviItem}-->
             <!--{else}-->
                 <!--{include file=$HeaderInternalNaviItem.tpl_path items=$HeaderInternalNaviItem}-->
             <!--{/if}-->

--- a/data/Smarty/templates/mobile/mypage/history.tpl
+++ b/data/Smarty/templates/mobile/mypage/history.tpl
@@ -59,10 +59,10 @@
             <!--{$arrProductType[$orderDetail.product_type_id]}--><br>
         <!--{/if}-->
         単価：
-        <!--{assign var=price value=`$orderDetail.price`}-->
-        <!--{assign var=quantity value=`$orderDetail.quantity`}-->
-        <!--{assign var=tax_rate value=`$orderDetail.tax_rate`}-->
-        <!--{assign var=tax_rule value=`$orderDetail.tax_rule`}-->
+        <!--{assign var=price value="`$orderDetail.price`"}-->
+        <!--{assign var=quantity value="`$orderDetail.quantity`"}-->
+        <!--{assign var=tax_rate value="`$orderDetail.tax_rate`"}-->
+        <!--{assign var=tax_rule value="`$orderDetail.tax_rule`"}-->
         <!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|n2s|h}-->円<br>
         数量：<!--{$quantity|h}--><br>
         小計：<!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|sfMultiply:$quantity|n2s}-->円<br>

--- a/data/Smarty/templates/mobile/shopping/confirm.tpl
+++ b/data/Smarty/templates/mobile/shopping/confirm.tpl
@@ -46,7 +46,7 @@
         【購入金額】<br>
         商品合計：<!--{$tpl_total_inctax[$cartKey]|n2s}-->円<br>
         <!--{if $smarty.const.USE_POINT !== false}-->
-            <!--{assign var=discount value=`$arrForm.use_point*$smarty.const.POINT_VALUE`}-->
+            <!--{assign var=discount value="`$arrForm.use_point*$smarty.const.POINT_VALUE`"}-->
             ポイント値引き：-<!--{$discount|n2s|default:0}-->円<br>
         <!--{/if}-->
         送料：<!--{$arrForm.deliv_fee|n2s}-->円<br>
@@ -62,7 +62,7 @@
             ご使用ポイント：-<!--{$arrForm.use_point|n2s|default:0}-->Pt<br>
             <!--{if $arrForm.birth_point > 0}-->お誕生月ポイント：+<!--{$arrForm.birth_point|n2s|default:0}-->Pt<br><!--{/if}-->
             今回加算予定のポイント：+<!--{$arrForm.add_point|n2s|default:0}-->Pt<br>
-            <!--{assign var=total_point value=`$tpl_user_point-$arrForm.use_point+$arrForm.add_point`}-->
+            <!--{assign var=total_point value="`$tpl_user_point-$arrForm.use_point+$arrForm.add_point`"}-->
             加算後のポイント：<!--{$total_point|n2s}-->Pt<br>
 
             <br>

--- a/data/Smarty/templates/mobile/site_frame.tpl
+++ b/data/Smarty/templates/mobile/site_frame.tpl
@@ -45,7 +45,7 @@
                 <!--{foreach key=HeadNaviKey item=HeadNaviItem from=$arrPageLayout.HeadNavi}-->
                     <!-- ▼「<!--{$HeadNaviItem.bloc_name|h}-->」ブロック -->
                     <!--{if $HeadNaviItem.php_path != ""}-->
-                        <!--{include_php file=$HeadNaviItem.php_path items=$HeadNaviItem}-->
+                        <!--{include_php_ex file=$HeadNaviItem.php_path items=$HeadNaviItem}-->
                     <!--{else}-->
                         <!--{include file=$HeadNaviItem.tpl_path items=$HeadNaviItem}-->
                     <!--{/if}-->

--- a/data/Smarty/templates/mobile/site_main.tpl
+++ b/data/Smarty/templates/mobile/site_main.tpl
@@ -27,7 +27,7 @@
         <a name="top" id="top"></a>
         <!--{* Moba8リクエスト用 *}-->
         <!--{if "sfRequestMoba8"|function_exists === TRUE}-->
-            <!--{include file=`$smarty.const.MODULE_REALDIR`mdl_moba8/request_moba8.tpl}-->
+            <!--{include file="`$smarty.const.MODULE_REALDIR`mdl_moba8/request_moba8.tpl"}-->
         <!--{/if}-->
 
         <!--{* ▼HeaderHeaderTop COLUMN *}-->
@@ -36,7 +36,7 @@
             <!--{foreach key=HeaderTopNaviKey item=HeaderTopNaviItem from=$arrPageLayout.HeaderTopNavi}-->
                 <!-- ▼<!--{$HeaderTopNaviItem.bloc_name}--> -->
                 <!--{if $HeaderTopNaviItem.php_path != ""}-->
-                    <!--{include_php file=$HeaderTopNaviItem.php_path items=$HeaderTopNaviItem}-->
+                    <!--{include_php_ex file=$HeaderTopNaviItem.php_path items=$HeaderTopNaviItem}-->
                 <!--{else}-->
                     <!--{include file=$HeaderTopNaviItem.tpl_path items=$HeaderTopNaviItem}-->
                 <!--{/if}-->
@@ -58,7 +58,7 @@
             <!--{foreach key=TopNaviKey item=TopNaviItem from=$arrPageLayout.TopNavi}-->
                 <!-- ▼<!--{$TopNaviItem.bloc_name}--> -->
                 <!--{if $TopNaviItem.php_path != ""}-->
-                    <!--{include_php file=$TopNaviItem.php_path items=$TopNaviItem}-->
+                    <!--{include_php_ex file=$TopNaviItem.php_path items=$TopNaviItem}-->
                 <!--{else}-->
                     <!--{include file=$TopNaviItem.tpl_path items=$TopNaviItem}-->
                 <!--{/if}-->
@@ -73,7 +73,7 @@
             <!--{foreach key=MainHeadKey item=MainHeadItem from=$arrPageLayout.MainHead}-->
                 <!-- ▼<!--{$MainHeadItem.bloc_name}--> -->
                 <!--{if $MainHeadItem.php_path != ""}-->
-                    <!--{include_php file=$MainHeadItem.php_path items=$MainHeadItem}-->
+                    <!--{include_php_ex file=$MainHeadItem.php_path items=$MainHeadItem}-->
                 <!--{else}-->
                     <!--{include file=$MainHeadItem.tpl_path items=$MainHeadItem}-->
                 <!--{/if}-->
@@ -91,7 +91,7 @@
             <!--{foreach key=MainFootKey item=MainFootItem from=$arrPageLayout.MainFoot}-->
                 <!-- ▼<!--{$MainFootItem.bloc_name}--> -->
                 <!--{if $MainFootItem.php_path != ""}-->
-                    <!--{include_php file=$MainFootItem.php_path items=$MainFootItem}-->
+                    <!--{include_php_ex file=$MainFootItem.php_path items=$MainFootItem}-->
                 <!--{else}-->
                     <!--{include file=$MainFootItem.tpl_path items=$MainFootItem}-->
                 <!--{/if}-->
@@ -106,7 +106,7 @@
             <!--{foreach key=BottomNaviKey item=BottomNaviItem from=$arrPageLayout.BottomNavi}-->
                 <!-- ▼<!--{$BottomNaviItem.bloc_name}--> -->
                 <!--{if $BottomNaviItem.php_path != ""}-->
-                    <!--{include_php file=$BottomNaviItem.php_path items=$BottomNaviItem}-->
+                    <!--{include_php_ex file=$BottomNaviItem.php_path items=$BottomNaviItem}-->
                 <!--{else}-->
                     <!--{include file=$BottomNaviItem.tpl_path items=$BottomNaviItem}-->
                 <!--{/if}-->
@@ -128,7 +128,7 @@
             <!--{foreach key=FooterBottomNaviKey item=FooterBottomNaviItem from=$arrPageLayout.FooterBottomNavi}-->
                 <!-- ▼<!--{$FooterBottomNaviItem.bloc_name}--> -->
                 <!--{if $FooterBottomNaviItem.php_path != ""}-->
-                    <!--{include_php file=$FooterBottomNaviItem.php_path items=$BottomNaviItem}-->
+                    <!--{include_php_ex file=$FooterBottomNaviItem.php_path items=$BottomNaviItem}-->
                 <!--{else}-->
                     <!--{include file=$FooterBottomNaviItem.tpl_path items=$FooterBottomNaviItem}-->
                 <!--{/if}-->

--- a/data/Smarty/templates/sphone/frontparts/bloc/category_tree_fork.tpl
+++ b/data/Smarty/templates/sphone/frontparts/bloc/category_tree_fork.tpl
@@ -29,7 +29,7 @@
             <!--{else}-->
                 <!--{assign var=disp_child value=0}-->
             <!--{/if}-->
-            <!--{if isset($child.children|smarty:nodefaults)}-->
+            <!--{if isset($child.children)}-->
                 <!--{include file="`$smarty.const.SMARTPHONE_TEMPLATE_REALDIR`frontparts/bloc/category_tree_fork.tpl" children=$child.children treeID="" display=$disp_child level=$child.level}-->
             <!--{/if}-->
         </li>

--- a/data/Smarty/templates/sphone/header.tpl
+++ b/data/Smarty/templates/sphone/header.tpl
@@ -31,7 +31,7 @@
                 <!--{foreach key=HeaderInternalNaviKey item=HeaderInternalNaviItem from=$arrPageLayout.HeaderInternalNavi}-->
                     <!-- ▼<!--{$HeaderInternalNaviItem.bloc_name}--> -->
                     <!--{if $HeaderInternalNaviItem.php_path != ""}-->
-                        <!--{include_php file=$HeaderInternalNaviItem.php_path items=$HeaderInternalNaviItem}-->
+                        <!--{include_php_ex file=$HeaderInternalNaviItem.php_path items=$HeaderInternalNaviItem}-->
                     <!--{else}-->
                         <!--{include file=$HeaderInternalNaviItem.tpl_path items=$HeaderInternalNaviItem}-->
                     <!--{/if}-->

--- a/data/Smarty/templates/sphone/mypage/favorite.tpl
+++ b/data/Smarty/templates/sphone/mypage/favorite.tpl
@@ -27,7 +27,7 @@
     <!--{if $tpl_navi != ""}-->
         <!--{include file=$tpl_navi}-->
     <!--{else}-->
-        <!--{include file=`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl}-->
+        <!--{include file="`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl"}-->
     <!--{/if}-->
 
     <h3 class="title_mypage"><!--{$tpl_subtitle|h}--></h3>

--- a/data/Smarty/templates/sphone/mypage/history.tpl
+++ b/data/Smarty/templates/sphone/mypage/history.tpl
@@ -100,8 +100,8 @@
                                 <p><em><!--→商品名--><a<!--{if $orderDetail.enable}--> href="<!--{$smarty.const.P_DETAIL_URLPATH}--><!--{$orderDetail.product_id|u}-->"<!--{/if}--> rel="external"><!--{$orderDetail.product_name|h}--></a><!--←商品名--></em></p>
                                 <p>
                                     <!--→金額-->
-                                    <!--{assign var=price value=`$orderDetail.price`}-->
-                                    <!--{assign var=quantity value=`$orderDetail.quantity`}-->
+                                    <!--{assign var=price value="`$orderDetail.price`"}-->
+                                    <!--{assign var=quantity value="`$orderDetail.quantity`"}-->
                                     <span class="mini">価格:</span><!--{$price|n2s|h}-->円<!--←金額-->
                                 </p>
 
@@ -121,8 +121,8 @@
                                 <!--{/if}-->
                                 <!--←商品種別-->
                             </div>
-                            <!--{assign var=tax_rate value=`$orderDetail.tax_rate`}-->
-                            <!--{assign var=tax_rule value=`$orderDetail.tax_rule`}-->
+                            <!--{assign var=tax_rate value="`$orderDetail.tax_rate`"}-->
+                            <!--{assign var=tax_rule value="`$orderDetail.tax_rule`"}-->
                             <ul>
                                 <li><span class="mini">数量：</span><!--{$quantity|h}--></li>
                                 <li class="result"><span class="mini">小計：</span><!--{$price|sfCalcIncTax:$tax_rate:$tax_rule|sfMultiply:$quantity|n2s}-->円</li>

--- a/data/Smarty/templates/sphone/mypage/index.tpl
+++ b/data/Smarty/templates/sphone/mypage/index.tpl
@@ -28,7 +28,7 @@
         <!--{if $tpl_navi != ""}-->
             <!--{include file=$tpl_navi}-->
         <!--{else}-->
-            <!--{include file=`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl}-->
+            <!--{include file="`$smarty.const.TEMPLATE_REALDIR`mypage/navi.tpl"}-->
         <!--{/if}-->
 
         <form name="form1" id="form1" method="post" action="<!--{$smarty.const.ROOT_URLPATH}-->mypage/index.php">

--- a/data/Smarty/templates/sphone/products/detail.tpl
+++ b/data/Smarty/templates/sphone/products/detail.tpl
@@ -88,7 +88,7 @@
 
             <!--{* 画像の縦横倍率を算出 *}-->
             <!--{assign var=detail_image_size value=200}-->
-            <!--{assign var=main_image_factor value=`$arrFile[$key].width/$detail_image_size`}-->
+            <!--{assign var=main_image_factor value="`$arrFile[$key].width/$detail_image_size"`}-->
             <!--{if $arrProduct.main_large_image|strlen >= 1}-->
                 <a rel="external" class="expansion" href="<!--{$smarty.const.IMAGE_SAVE_URLPATH}--><!--{$arrProduct.main_large_image|h}-->" target="_blank">
                     <img src="<!--{$smarty.const.IMAGE_SAVE_URLPATH}--><!--{$arrProduct.main_image|h}-->" alt="<!--{$arrProduct.name|h}-->" width="<!--{$arrFile.main_image.width/$main_image_factor}-->" height="<!--{$arrFile.main_image.height/$main_image_factor}-->" /></a>
@@ -99,7 +99,7 @@
             <!--★サブ画像★-->
             <!--{section name=cnt loop=$smarty.const.PRODUCTSUB_MAX}-->
             <!--{assign var=key value="sub_image`$smarty.section.cnt.index+1`"}-->
-            <!--{assign var=sub_image_factor value=`$arrFile[$key].width/$detail_image_size`}-->
+            <!--{assign var=sub_image_factor value="`$arrFile[$key].width/$detail_image_size`"}-->
             <!--{assign var=lkey value="sub_large_image`$smarty.section.cnt.index+1`"}-->
             <!--{if $arrFile[$key].filepath != ""}-->
                 <li id="mainImage<!--{$smarty.section.cnt.index+1}-->">
@@ -329,7 +329,7 @@
                         <!--{assign var=key value="sub_image`$smarty.section.cnt.index+1`"}-->
                         <!--{assign var=lkey value="sub_large_image`$smarty.section.cnt.index+1`"}-->
                         <!--{assign var=ckey value="sub_comment`$smarty.section.cnt.index+1`"}-->
-                        <!--{assign var=sub_image_factor value=`$arrFile[$key].width/$sub_image_size`}-->
+                        <!--{assign var=sub_image_factor value="`$arrFile[$key].width/$sub_image_size`"}-->
                         <!--{if $arrProduct[$key]|strlen >= 1}-->
                             <p class="subphotoimg">
                                 <!--{if $arrProduct[$lkey]|strlen >= 1}-->
@@ -396,8 +396,8 @@
                     <!--{if $arrRecommend[cnt].product_id}-->
                         <li id="mainImage1<!--{$smarty.section.cnt.index}-->">
                             <img src="<!--{$smarty.const.IMAGE_SAVE_URLPATH}--><!--{$arrRecommend[cnt].main_list_image|sfNoImageMainList|h}-->" style="max-width: 65px;max-height: 65px;" alt="!--{$arrRecommend[cnt].name|h}-->" />
-                            <!--{assign var=price02_min value=`$arrRecommend[cnt].price02_min_inctax`}-->
-                            <!--{assign var=price02_max value=`$arrRecommend[cnt].price02_max_inctax`}-->
+                            <!--{assign var=price02_min value="`$arrRecommend[cnt].price02_min_inctax`"}-->
+                            <!--{assign var=price02_max value="`$arrRecommend[cnt].price02_max_inctax`"}-->
                             <h3><a rel="external" href="<!--{$smarty.const.P_DETAIL_URLPATH}--><!--{$arrRecommend[cnt].product_id|u}-->"><!--{$arrRecommend[cnt].name|h}--></a></h3>
                             <p class="sale_price"><span class="price">
                                 <!--{if $price02_min == $price02_max}-->

--- a/data/Smarty/templates/sphone/shopping/confirm.tpl
+++ b/data/Smarty/templates/sphone/shopping/confirm.tpl
@@ -125,7 +125,7 @@
                         <ul>
                             <li><span class="mini">小計 ：</span><!--{$tpl_total_inctax[$cartKey]|n2s}--> 円</li>
                             <!--{if $smarty.const.USE_POINT !== false}-->
-                                <li><span class="mini">値引き（ポイントご使用時）： </span><!--{assign var=discount value=`$arrForm.use_point*$smarty.const.POINT_VALUE`}-->
+                                <li><span class="mini">値引き（ポイントご使用時）： </span><!--{assign var=discount value="`$arrForm.use_point*$smarty.const.POINT_VALUE`"}-->
                                 -<!--{$discount|n2s|default:0}--> 円</li>
                             <!--{/if}-->
                             <li><span class="mini">送料 ：</span><!--{$arrForm.deliv_fee|n2s}--> 円</li>
@@ -158,7 +158,7 @@
                             <dt>今回加算予定のポイント</dt><dd>+<!--{$arrForm.add_point|n2s|default:0}-->Pt</dd>
                         </dl>
                         <dl>
-                            <!--{assign var=total_point value=`$tpl_user_point-$arrForm.use_point+$arrForm.add_point`}-->
+                            <!--{assign var=total_point value="`$tpl_user_point-$arrForm.use_point+$arrForm.add_point`"}-->
                             <dt>加算後のポイント</dt><dd><!--{$total_point|n2s}-->Pt</dd>
                         </dl>
                     </div><!-- /.formBox -->

--- a/data/Smarty/templates/sphone/site_frame.tpl
+++ b/data/Smarty/templates/sphone/site_frame.tpl
@@ -89,7 +89,7 @@
                 <!--{foreach key=HeadNaviKey item=HeadNaviItem from=$arrPageLayout.HeadNavi}-->
                     <!--{* ▼<!--{$HeadNaviItem.bloc_name}--> *}-->
                         <!--{if $HeadNaviItem.php_path != ""}-->
-                            <!--{include_php file=$HeadNaviItem.php_path items=$HeadNaviItem}-->
+                            <!--{include_php_ex file=$HeadNaviItem.php_path items=$HeadNaviItem}-->
                         <!--{else}-->
                             <!--{include file=$HeadNaviItem.tpl_path items=$HeadNaviItem}-->
                         <!--{/if}-->

--- a/data/Smarty/templates/sphone/site_main.tpl
+++ b/data/Smarty/templates/sphone/site_main.tpl
@@ -30,7 +30,7 @@
                 <!--{foreach key=HeaderTopNaviKey item=HeaderTopNaviItem from=$arrPageLayout.HeaderTopNavi}-->
                     <!-- ▼<!--{$HeaderTopNaviItem.bloc_name}--> -->
                     <!--{if $HeaderTopNaviItem.php_path != ""}-->
-                        <!--{include_php file=$HeaderTopNaviItem.php_path items=$HeaderTopNaviItem}-->
+                        <!--{include_php_ex file=$HeaderTopNaviItem.php_path items=$HeaderTopNaviItem}-->
                     <!--{else}-->
                         <!--{include file=$HeaderTopNaviItem.tpl_path items=$HeaderTopNaviItem}-->
                     <!--{/if}-->
@@ -55,7 +55,7 @@
                 <!--{foreach key=TopNaviKey item=TopNaviItem from=$arrPageLayout.TopNavi}-->
                     <!-- ▼<!--{$TopNaviItem.bloc_name}--> -->
                     <!--{if $TopNaviItem.php_path != ""}-->
-                        <!--{include_php file=$TopNaviItem.php_path items=$TopNaviItem}-->
+                        <!--{include_php_ex file=$TopNaviItem.php_path items=$TopNaviItem}-->
                     <!--{else}-->
                         <!--{include file=$TopNaviItem.tpl_path items=$TopNaviItem}-->
                     <!--{/if}-->
@@ -73,7 +73,7 @@
                 <!--{foreach key=MainHeadKey item=MainHeadItem from=$arrPageLayout.MainHead}-->
                     <!-- ▼<!--{$MainHeadItem.bloc_name}--> -->
                     <!--{if $MainHeadItem.php_path != ""}-->
-                        <!--{include_php file=$MainHeadItem.php_path items=$MainHeadItem}-->
+                        <!--{include_php_ex file=$MainHeadItem.php_path items=$MainHeadItem}-->
                     <!--{else}-->
                         <!--{include file=$MainHeadItem.tpl_path items=$MainHeadItem}-->
                     <!--{/if}-->
@@ -91,7 +91,7 @@
                 <!--{foreach key=MainFootKey item=MainFootItem from=$arrPageLayout.MainFoot}-->
                     <!-- ▼<!--{$MainFootItem.bloc_name}--> -->
                     <!--{if $MainFootItem.php_path != ""}-->
-                        <!--{include_php file=$MainFootItem.php_path items=$MainFootItem}-->
+                        <!--{include_php_ex file=$MainFootItem.php_path items=$MainFootItem}-->
                     <!--{else}-->
                         <!--{include file=$MainFootItem.tpl_path items=$MainFootItem}-->
                     <!--{/if}-->
@@ -109,7 +109,7 @@
                 <!--{foreach key=BottomNaviKey item=BottomNaviItem from=$arrPageLayout.BottomNavi}-->
                     <!-- ▼<!--{$BottomNaviItem.bloc_name}--> -->
                     <!--{if $BottomNaviItem.php_path != ""}-->
-                        <!--{include_php file=$BottomNaviItem.php_path items=$BottomNaviItem}-->
+                        <!--{include_php_ex file=$BottomNaviItem.php_path items=$BottomNaviItem}-->
                     <!--{else}-->
                         <!--{include file=$BottomNaviItem.tpl_path items=$BottomNaviItem}-->
                     <!--{/if}-->
@@ -134,7 +134,7 @@
                 <!--{foreach key=FooterBottomNaviKey item=FooterBottomNaviItem from=$arrPageLayout.FooterBottomNavi}-->
                     <!-- ▼<!--{$FooterBottomNaviItem.bloc_name}--> -->
                     <!--{if $FooterBottomNaviItem.php_path != ""}-->
-                        <!--{include_php file=$FooterBottomNaviItem.php_path items=$FooterBottomNaviItem}-->
+                        <!--{include_php_ex file=$FooterBottomNaviItem.php_path items=$FooterBottomNaviItem}-->
                     <!--{else}-->
                         <!--{include file=$FooterBottomNaviItem.tpl_path items=$FooterBottomNaviItem}-->
                     <!--{/if}-->

--- a/data/class/SC_View.php
+++ b/data/class/SC_View.php
@@ -23,9 +23,9 @@
 
 class SC_View
 {
-    public $_smarty;
+    var $_smarty;
 
-    public $objPage;
+    var $objPage;
 
     // コンストラクタ
     public function __construct()
@@ -35,27 +35,29 @@ class SC_View
 
     public function init()
     {
-        $this->_smarty = new Smarty;
+        // include_phpの利用のためSmartyBCを呼び出す、ホントはinclude_phpをなくしたいそうすれば、blank.tplもなくせる
+        $this->_smarty = new SmartyBC;
+
         $this->_smarty->left_delimiter = '<!--{';
         $this->_smarty->right_delimiter = '}-->';
-        $this->_smarty->register_modifier('sfDispDBDate', array('SC_Utils_Ex', 'sfDispDBDate'));
-        $this->_smarty->register_modifier('sfGetErrorColor', array('SC_Utils_Ex', 'sfGetErrorColor'));
-        $this->_smarty->register_modifier('sfTrim', array('SC_Utils_Ex', 'sfTrim'));
-        $this->_smarty->register_modifier('sfCalcIncTax', array('SC_Helper_DB_Ex', 'sfCalcIncTax'));
-        $this->_smarty->register_modifier('sfPrePoint', array('SC_Utils_Ex', 'sfPrePoint'));
-        $this->_smarty->register_modifier('sfGetChecked', array('SC_Utils_Ex', 'sfGetChecked'));
-        $this->_smarty->register_modifier('sfTrimURL', array('SC_Utils_Ex', 'sfTrimURL'));
-        $this->_smarty->register_modifier('sfMultiply', array('SC_Utils_Ex', 'sfMultiply'));
-        $this->_smarty->register_modifier('sfRmDupSlash', array('SC_Utils_Ex', 'sfRmDupSlash'));
-        $this->_smarty->register_modifier('sfCutString', array('SC_Utils_Ex', 'sfCutString'));
-        $this->_smarty->plugins_dir=array('plugins', realpath(dirname(__FILE__)) . '/../smarty_extends');
-        $this->_smarty->register_modifier('sfMbConvertEncoding', array('SC_Utils_Ex', 'sfMbConvertEncoding'));
-        $this->_smarty->register_modifier('sfGetEnabled', array('SC_Utils_Ex', 'sfGetEnabled'));
-        $this->_smarty->register_modifier('sfNoImageMainList', array('SC_Utils_Ex', 'sfNoImageMainList'));
+        $this->_smarty->registerPlugin('modifier', 'sfDispDBDate', array('SC_Utils_Ex', 'sfDispDBDate'));
+        $this->_smarty->registerPlugin('modifier', 'sfGetErrorColor', array('SC_Utils_Ex', 'sfGetErrorColor'));
+        $this->_smarty->registerPlugin('modifier', 'sfTrim', array('SC_Utils_Ex', 'sfTrim'));
+        $this->_smarty->registerPlugin('modifier', 'sfCalcIncTax', array('SC_Helper_DB_Ex', 'sfCalcIncTax'));
+        $this->_smarty->registerPlugin('modifier', 'sfPrePoint', array('SC_Utils_Ex', 'sfPrePoint'));
+        $this->_smarty->registerPlugin('modifier', 'sfGetChecked',array('SC_Utils_Ex', 'sfGetChecked'));
+        $this->_smarty->registerPlugin('modifier', 'sfTrimURL', array('SC_Utils_Ex', 'sfTrimURL'));
+        $this->_smarty->registerPlugin('modifier', 'sfMultiply', array('SC_Utils_Ex', 'sfMultiply'));
+        $this->_smarty->registerPlugin('modifier', 'sfRmDupSlash', array('SC_Utils_Ex', 'sfRmDupSlash'));
+        $this->_smarty->registerPlugin('modifier', 'sfCutString', array('SC_Utils_Ex', 'sfCutString'));
+        $this->_smarty->addPluginsDir(array('plugins', realpath(dirname(__FILE__)) . '/../smarty_extends'));
+        $this->_smarty->registerPlugin('modifier', 'sfMbConvertEncoding', array('SC_Utils_Ex', 'sfMbConvertEncoding'));
+        $this->_smarty->registerPlugin('modifier', 'sfGetEnabled', array('SC_Utils_Ex', 'sfGetEnabled'));
+        $this->_smarty->registerPlugin('modifier', 'sfNoImageMainList', array('SC_Utils_Ex', 'sfNoImageMainList'));
         // XXX register_function で登録すると if で使用できないのではないか？
-        $this->_smarty->register_function('sfIsHTTPS', array('SC_Utils_Ex', 'sfIsHTTPS'));
-        $this->_smarty->register_function('sfSetErrorStyle', array('SC_Utils_Ex', 'sfSetErrorStyle'));
-        $this->_smarty->register_function('printXMLDeclaration', array('GC_Utils_Ex', 'printXMLDeclaration'));
+        $this->_smarty->registerPlugin('function','sfIsHTTPS', array('SC_Utils_Ex', 'sfIsHTTPS'));
+        $this->_smarty->registerPlugin('function','sfSetErrorStyle', array('SC_Utils_Ex', 'sfSetErrorStyle'));
+        $this->_smarty->registerPlugin('function','printXMLDeclaration', array('GC_Utils_Ex', 'printXMLDeclaration'));
         $this->_smarty->default_modifiers = array('script_escape');
 
         if (ADMIN_MODE == '1') {
@@ -126,24 +128,22 @@ class SC_View
      */
     public function registFilter()
     {
-        $this->_smarty->register_prefilter(array(&$this, 'prefilter_transform'));
-        $this->_smarty->register_outputfilter(array(&$this, 'outputfilter_transform'));
+        $this->_smarty->registerFilter('pre', array(&$this, 'prefilter_transform'));
+        $this->_smarty->registerFilter('output', array(&$this, 'outputfilter_transform'));
     }
 
     /**
      * prefilter用のフィルタ関数。プラグイン用のフックポイント処理を実行
      * @param  string          $source ソース
-     * @param  Smarty_Compiler $smarty Smartyのコンパイラクラス
+     * @param  Smarty_Internal_Template $smarty Smartyのコンパイラクラス
      * @return string          $source ソース
      */
-    public function prefilter_transform($source, &$smarty)
+    public function prefilter_transform($source, Smarty_Internal_Template $template)
     {
         if (!is_null($this->objPage)) {
             // フックポイントを実行.
             $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->objPage->plugin_activate_flg);
-            if (is_object($objPlugin)) {
-                $objPlugin->doAction('prefilterTransform', array(&$source, $this->objPage, $smarty->_current_file));
-            }
+            $objPlugin->doAction('prefilterTransform', array(&$source, $this->objPage, $template->smarty->_current_file));
         }
 
         return $source;
@@ -152,23 +152,25 @@ class SC_View
     /**
      * outputfilter用のフィルタ関数。プラグイン用のフックポイント処理を実行
      * @param  string          $source ソース
-     * @param  Smarty_Compiler $smarty Smartyのコンパイラクラス
+     * @param  Smarty_Internal_Template $smarty Smartyのコンパイラクラス
      * @return string          $source ソース
      */
-    public function outputfilter_transform($source, &$smarty)
+    public function outputfilter_transform($source, Smarty_Internal_Template $template)
     {
         if (!is_null($this->objPage)) {
             // フックポイントを実行.
             $objPlugin = SC_Helper_Plugin_Ex::getSingletonInstance($this->objPage->plugin_activate_flg);
-            if (is_object($objPlugin)) {
-                $objPlugin->doAction('outputfilterTransform', array(&$source, $this->objPage, $smarty->_current_file));
-            }
+            $objPlugin->doAction('outputfilterTransform', array(&$source, $this->objPage, $template->smarty->_current_file));
         }
 
         return $source;
     }
 
-    // テンプレートの処理結果を表示
+    /**
+     * テンプレートの処理結果を表示
+     * @param string $template
+     * @param bool $no_error
+     */
     public function display($template, $no_error = false)
     {
         if (!$no_error) {
@@ -188,7 +190,10 @@ class SC_View
         }
     }
 
-    // オブジェクト内の変数を全て割り当てる。
+    /**
+     * オブジェクト内の変数を全て割り当てる。
+     * @param object $obj
+     */
     public function assignobj($obj)
     {
         $data = get_object_vars($obj);
@@ -198,7 +203,10 @@ class SC_View
         }
     }
 
-    // 連想配列内の変数を全て割り当てる。
+    /**
+     * 連想配列内の変数を全て割り当てる。
+     * @param array $array
+     */
     public function assignarray($array)
     {
         foreach ($array as $key => $val) {
@@ -225,7 +233,10 @@ class SC_View
         $this->assign('footer_tpl', $footer_tpl);
     }
 
-    // デバッグ
+    /**
+     * デバッグ
+     * @param bool $var
+     */
     public function debug($var = true)
     {
         $this->_smarty->debugging = $var;

--- a/data/smarty_extends/function.include_php_ex.php
+++ b/data/smarty_extends/function.include_php_ex.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Smarty plugin
+ * @package Smarty
+ * @subpackage plugins
+ */
+
+
+/**
+ * Smarty {include_php_ex} function plugin
+ * include_php が非推奨なのでこちらで代用する
+ *
+ *
+ * @param array $params
+ * @param Smarty $smarty
+ * @return void
+ */
+function smarty_function_include_php_ex($params, &$smarty)
+{
+    extract($params);
+
+    if(! isset($file) ){
+        return false ;
+    }
+
+    if(! file_exists($file) ){
+        return false ;
+    }
+
+    if( isset($once) && $once === false){
+        require $file ;
+    } else {
+        require_once $file ;
+    }
+
+    return ;
+}


### PR DESCRIPTION
smarty3 に対応するために、修正したところ
include_php を利用が問題なので、 include_php_ex のfunctionをつくって、そちらを参照するように調整。 -> 表示はできてるか、データが入った時の検証があまいので、再度検証はする必要あり。

smarty:nodefaults -> nofilter smarty3での変更に対応

バッククオートが入っている場合、ダブルコーテーションで囲んでないとエラーになる場合があるので囲んだ。ex) value=`$hoge[fuga]` ->  value="`$hoge[fuga]` "

isset($child.children|smarty:nodefaults)　issetの中で、|smarty:nodefaultsは使えないので削除

一応ざっくり全ページ表示しましたが、エラーで表示できないページが存在した場合は error.logを見るとどのファイルの行数まででてるので、都度潰していけば大丈夫かと思います。
