### PR TITLE
MySQL8対応

### DIFF
--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -370,7 +370,7 @@ __EOS__;
      */
     public function initObjQuery(SC_Query &$objQuery)
     {
-        if ($objQuery->conn->getConnection()->server_version >= 50750) {
+        if ($objQuery->conn->getConnection()->server_version >= 50705) {
             $objQuery->exec('SET SESSION default_storage_engine = InnoDB');
         } else {
             $objQuery->exec('SET SESSION storage_engine = InnoDB');

--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -360,7 +360,11 @@ __EOS__;
      */
     public function initObjQuery(SC_Query &$objQuery)
     {
-        $objQuery->exec('SET SESSION storage_engine = InnoDB');
+        if ($objQuery->conn->getConnection()->server_version >= 50750) {
+            $objQuery->exec('SET SESSION default_storage_engine = InnoDB');
+        } else {
+            $objQuery->exec('SET SESSION storage_engine = InnoDB');
+        }
         $objQuery->exec("SET SESSION sql_mode = 'ANSI'");
     }
 }

--- a/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
+++ b/data/class/db/dbfactory/SC_DB_DBFactory_MYSQL.php
@@ -70,7 +70,8 @@ class SC_DB_DBFactory_MYSQL extends SC_DB_DBFactory
         $sql = $this->sfChangeTrunc($sql);
         // ARRAY_TO_STRINGをGROUP_CONCATに変換する
         $sql = $this->sfChangeArrayToString($sql);
-
+        // rank に引用符をつける
+        $sql = $this->sfChangeReservedWords($sql);
         return $sql;
     }
 
@@ -340,6 +341,15 @@ __EOS__;
         }
 
         return $definition;
+    }
+
+    /**
+     * 予約語に引用符を付与する.
+     */
+    public function sfChangeReservedWords($sql)
+    {
+        $changesql = preg_replace('/(^|[^\w])RANK([^\w]|$)/i', '$1`RANK`$2', $sql);
+        return $changesql;
     }
 
     /**

--- a/html/install/index.php
+++ b/html/install/index.php
@@ -851,7 +851,7 @@ function lfExecuteSQL($filepath, $arrDsn, $disp_err = true)
             // MySQL 用の初期化
             // XXX SC_Query を使うようにすれば、この処理は不要となる
             if ($arrDsn['phptype'] === 'mysqli') {
-                if ($objDB->getConnection()->server_version >= 50750) {
+                if ($objDB->getConnection()->server_version >= 50705) {
                     $objDB->exec('SET SESSION defaut_storage_engine = InnoDB');
                 } else {
                     $objDB->exec('SET SESSION storage_engine = InnoDB');

--- a/html/install/index.php
+++ b/html/install/index.php
@@ -850,8 +850,12 @@ function lfExecuteSQL($filepath, $arrDsn, $disp_err = true)
 
             // MySQL 用の初期化
             // XXX SC_Query を使うようにすれば、この処理は不要となる
-            if ($arrDsn['phptype'] === 'mysql') {
-                $objDB->exec('SET SESSION storage_engine = InnoDB');
+            if ($arrDsn['phptype'] === 'mysqli') {
+                if ($objDB->getConnection()->server_version >= 50750) {
+                    $objDB->exec('SET SESSION defaut_storage_engine = InnoDB');
+                } else {
+                    $objDB->exec('SET SESSION storage_engine = InnoDB');
+                }
                 $objDB->exec("SET SESSION sql_mode = 'ANSI'");
             }
 

--- a/html/install/index.php
+++ b/html/install/index.php
@@ -863,6 +863,11 @@ function lfExecuteSQL($filepath, $arrDsn, $disp_err = true)
             foreach ($sql_split as $key => $val) {
                 SC_Utils::sfFlush(true);
                 if (trim($val) != '') {
+                    if ($arrDsn['phptype'] === 'mysqli') {
+                        // rank は予約語なので MySQL8 から引用符をつけないとエラーになる
+                        $dbFactory = SC_DB_DBFactory_Ex::getInstance($arrDsn['phptype']);
+                        $val = $dbFactory->sfChangeReservedWords($val);
+                    }
                     $ret = $objDB->query($val);
                     if (PEAR::isError($ret) && $disp_err) {
                         $arrErr['all'] = '>> ' . $ret->message . '<br />';


### PR DESCRIPTION
- MySQL5.7.5 以降で `SET SESSION storage_engine = InnoDB` がエラーになるのを修正
- rank がエラーになるようになったため、引用符を付与する